### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.vscode
+node_modules
+build
+*.log
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Base Image
+FROM node:16-alpine
+# Setting up node env
+ENV NODE_ENV=production
+RUN npm install -g serve
+# Setting up workspace
+WORKDIR /app
+# Copy only required files for downloading
+# node modules for caching purposes
+COPY package.json package-lock.json ./
+# Downloading node modules
+RUN npm ci
+# Copy application to the workspace
+COPY . .
+# Building production build
+RUN npm run build
+# Setting up and exposing dev server port
+ENV PORT=3000
+EXPOSE ${PORT}
+USER node
+# Starting dev server
+CMD serve -s build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,16 @@
+# Base Image
+FROM node:16-alpine
+# Setting up workspace
+WORKDIR /app
+# Copy only required files for downloading
+# node modules for caching purposes
+COPY package.json package-lock.json ./
+# Downloading node modules
+RUN npm install
+# Copy application to the workspace
+COPY . .
+# Setting up and exposing dev server port
+ENV PORT=3000
+EXPOSE ${PORT}
+# Starting dev server
+CMD [ "npm", "start" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
         "autoprefixer": "^10.4.8",
         "postcss": "^8.4.14",
         "tailwindcss": "^3.1.7"
+      },
+      "engines": {
+        "node": "^16.6.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "autoprefixer": "^10.4.8",
     "postcss": "^8.4.14",
     "tailwindcss": "^3.1.7"
+  },
+  "engines": {
+    "node": "^16.6.1"
   }
 }


### PR DESCRIPTION
Add two optional dockerfile for development and production purposes

### Development
#### Build
```sh
docker build . -f Dockerfile.dev -t foot-balance:dev
```
#### Run
```sh
docker run --rm -it -p 3000:3000 foot-balance:dev
```

Development server will start at localhost:3000

### Production
#### Build
```sh
docker build . -t foot-balance:latest
```
#### Run
```sh
docker run --rm -it -p 8080:3000 foot-balance:latest
```

Production server will start at localhost 8080
